### PR TITLE
bugfix for mousedown when scrolling

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -337,11 +337,13 @@ export function useDraggable(
       window.addEventListener("mouseup", onMouseUp);
       window.addEventListener("mousemove", onMouseMove);
       window.addEventListener("resize", handleResize);
+      window.addEventListener("mousedown", preventClick);
     }
     return () => {
       window.removeEventListener("mouseup", onMouseUp);
       window.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("resize", handleResize);
+      window.removeEventListener("mousedown", preventClick);
 
       clearInterval(keepMovingX);
       clearInterval(keepMovingY);


### PR DESCRIPTION
On Safari/ Firefox if the elements inside the scrollable div are links or images, the user first "grabs" the image then the scroll starts to move with the image floating in space, as a fix I have added an event listener to the children on mousedown to prevent click

https://user-images.githubusercontent.com/39632973/192761288-9fea86e7-78da-4502-83cd-3f65720caf9a.mov

