### PR TITLE
Revert "bugfix for mousedown when scrolling"

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -337,13 +337,11 @@ export function useDraggable(
       window.addEventListener("mouseup", onMouseUp);
       window.addEventListener("mousemove", onMouseMove);
       window.addEventListener("resize", handleResize);
-      window.addEventListener("mousedown", preventClick);
     }
     return () => {
       window.removeEventListener("mouseup", onMouseUp);
       window.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("resize", handleResize);
-      window.removeEventListener("mousedown", preventClick);
 
       clearInterval(keepMovingX);
       clearInterval(keepMovingY);


### PR DESCRIPTION
Reverts rfmiotto/react-use-draggable-scroll#16

After this fix, text highlighting stopped working, even outside the draggable zone.
@NikolaP93, we need to find another solution for your issue. 
